### PR TITLE
Handles self-closing tags

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -49,6 +49,10 @@ function activate(context) {
       };
 
       var formattedText = replaceAll(text, mapObj);
+      
+      // Handle self-closing tags
+      formattedText = formattedText.replace(/<(area|base|br|col|command|embed|hr|img|input|keygen|link|meta|param|source|track|wbr)([^>]*?)(?<!\/)>(<\/\1>|)/g, "<$1$2 />");
+
 
       editor.edit((editBuilder) =>
         editBuilder.replace(textRange, formattedText)


### PR DESCRIPTION
(area|base|br|col|...|wbr): Matches any of the listed void element tags.

([^>]*?): Captures any attributes inside the tag, if present.

(?<!\/)>: A negative lookbehind assertion that matches a > only if it's not preceded by a /. This ensures we don't modify already self-closing tags.

<\/\1>|: Matches the closing tag if present (which should be rare or non-existent for these elements). The \1 is a backreference to the matched tag name, ensuring we're matching the correct closing tag.

The replacement pattern "<$1$2 />" puts the tag and any attributes into the self-closing format.

With this transformation, all the listed void elements will be made self-closing if they aren't already.